### PR TITLE
Don't print any decimals when precision is 0

### DIFF
--- a/include/decimal.h
+++ b/include/decimal.h
@@ -480,8 +480,12 @@ void toStream(const decimal<prec> &arg, StreamType &output) {
     output << "-";
 
   const char dec_point = use_facet<numpunct<char> >(output.getloc()).decimal_point();
-  output << before << dec_point;
-  output << setw(arg.getDecimalPoints()) << setfill('0') << right << after;
+  output << before;
+  if(arg.getDecimalPoints() > 0)
+  {
+    output << dec_point;
+    output << setw(arg.getDecimalPoints()) << setfill('0') << right << after;
+  }
 }
 
 /// Converts stream of chars to decimal


### PR DESCRIPTION
When the precision is 0, i.e. dec::decimal\<0\>, then printing this value will print a decimal point and one decimal place. I think it should not print either of those. This patch just skips printing the decimal point and anything following if the precision is 0.