### PR TITLE
Doesn't have the lib <limts> cause problems

### DIFF
--- a/include/decimal.h
+++ b/include/decimal.h
@@ -40,6 +40,7 @@
 #include <iomanip>
 #include <sstream>
 #include <locale>
+#include <limits>
 
 #ifndef DEC_NO_CPP11
 #include <cstdint>


### PR DESCRIPTION
Well, i'm still learning C++, but i can say that if you don't include this libary
compiler bugs will happen. You can see more about the errors in this link:

http://stackoverflow.com/questions/28283452/decimal-h-c-libary-errors/28284260#28284260