### PR TITLE
Write directly on the stream

### DIFF
--- a/include/decimal.h
+++ b/include/decimal.h
@@ -656,8 +656,7 @@ template <class charT, class traits, int prec>
   std::basic_ostream<charT, traits> &
     operator<<(std::basic_ostream<charT, traits> & os, const decimal<prec> & d)
 {
-  std::string helper;
-  os << toString(d, helper);
+  toStream(d, os);
   return os;
 }
 


### PR DESCRIPTION
The stream insertion operator uses a string as an intermediary.  This seems unnecessary and it caused a problem for me since I set the locale on my output stream in order to get thousands separators.  Why not call toStream directly inside the stream insertion operator?