### PR TITLE
Fixed infinite loop problem on "getWithExponent"

### DIFF
--- a/include/decimal.h
+++ b/include/decimal.h
@@ -1013,10 +1013,12 @@ public:
         int64 value = m_value;
         int exp = -Prec;
 
-        // normalize
-        while (value % 10 == 0) {
-            value /= 10;
-            exp++;
+        if (value != 0) {
+            // normalize
+            while (value % 10 == 0) {
+                value /= 10;
+                exp++;
+            }
         }
 
         mantissa = value;


### PR DESCRIPTION
It was stuck on a infinite loop when m_value == 0 (decimal<Prec>(0))

The exp will have -Prec value. (0 * 10^ -P == 0 anyway) 