### PR TITLE
make some operators trivial

### DIFF
--- a/include/decimal.h
+++ b/include/decimal.h
@@ -625,12 +625,17 @@ public:
         decimal_points = Prec
     };
 
+#ifdef DEC_NO_CPP11
     decimal() {
         init(0);
     }
     decimal(const decimal &src) {
         init(src);
     }
+#else
+    decimal() noexcept : m_value(0) {}
+    decimal(const decimal &src) = default;
+#endif
     explicit decimal(uint value) {
         init(value);
     }
@@ -656,8 +661,12 @@ public:
         fromString(value, *this);
     }
 
+#ifdef DEC_NO_CPP11
     ~decimal() {
     }
+#else
+    ~decimal() = default;
+#endif
 
     static int64 getPrecFactor() {
         return DecimalFactor<Prec>::value;
@@ -666,11 +675,15 @@ public:
         return Prec;
     }
 
+#ifdef DEC_NO_CPP11
     decimal & operator=(const decimal &rhs) {
         if (&rhs != this)
             m_value = rhs.m_value;
         return *this;
     }
+#else
+    decimal & operator=(const decimal &rhs) = default;
+#endif
 
 #if DEC_TYPE_LEVEL == 1
     template<int Prec2>

--- a/tests/decimalTest.ipp
+++ b/tests/decimalTest.ipp
@@ -9,6 +9,7 @@
 
 #include "decimal.h"
 #include <boost/integer_traits.hpp>
+#include <type_traits>
 
 /*
 template <typename T>
@@ -1173,4 +1174,23 @@ BOOST_AUTO_TEST_CASE(decimalFromStringWithFormat) {
     dec::decimal<2> d2b(dec::fromString<dec::decimal<2>>(value2, format));
 
     BOOST_CHECK_EQUAL(d2a, d2b);
+}
+
+BOOST_AUTO_TEST_CASE(trivialAndNoThrowConstructor) {
+    BOOST_CHECK_EQUAL(std::is_trivial<dec::decimal<6>>::value, false);
+
+    BOOST_CHECK_EQUAL(std::is_trivially_constructible<dec::decimal<6>>::value, false);
+    BOOST_CHECK_EQUAL(std::is_nothrow_constructible<dec::decimal<6>>::value, true);
+
+    BOOST_CHECK_EQUAL(std::is_trivially_default_constructible<dec::decimal<6>>::value, false);
+    BOOST_CHECK_EQUAL(std::is_nothrow_default_constructible<dec::decimal<6>>::value, true);
+
+    BOOST_CHECK_EQUAL(std::is_trivially_copy_constructible<dec::decimal<6>>::value, true);
+    BOOST_CHECK_EQUAL(std::is_nothrow_copy_constructible<dec::decimal<6>>::value, true);
+
+    BOOST_CHECK_EQUAL(std::is_trivially_copy_assignable<dec::decimal<6>>::value, true);
+    BOOST_CHECK_EQUAL(std::is_nothrow_copy_assignable<dec::decimal<6>>::value, true);
+
+    BOOST_CHECK_EQUAL(std::is_trivially_destructible<dec::decimal<6>>::value, true);
+    BOOST_CHECK_EQUAL(std::is_nothrow_destructible<dec::decimal<6>>::value, true);
 }


### PR DESCRIPTION
Making the destructor, assignment operator and copy constructor trivial. Setting default constructor to noexcept.

The default constructor could be set to default too, but that would be a breaking change, it would not be set to 0.