### PR TITLE
Get as integer fix

### DIFF
--- a/include/decimal.h
+++ b/include/decimal.h
@@ -196,11 +196,25 @@ inline bool div_rounded(int64 &output, int64 a, int64 b) {
         if (DEC_MAX_INT64 - a >= divisorCorr) {
             output = (a + divisorCorr) / b;
             return true;
+        } else {
+            int64 i = a / b;
+            int64 r = a - i * b;
+            if (r < divisorCorr) {
+                output = i;
+                return true;
+            }
         }
     } else {
         if (-(DEC_MIN_INT64 - a) >= divisorCorr) {
             output = (a - divisorCorr) / b;
             return true;
+        } else {
+            int64 i = a / b;
+            int64 r = a - i * b;
+            if (r < divisorCorr) {
+                output = i;
+                return true;
+            }
         }
     }
 

--- a/include/decimal.h
+++ b/include/decimal.h
@@ -197,8 +197,8 @@ inline bool div_rounded(int64 &output, int64 a, int64 b) {
             output = (a + divisorCorr) / b;
             return true;
         } else {
-            int64 i = a / b;
-            int64 r = a - i * b;
+            const int64 i = a / b;
+            const int64 r = a - i * b;
             if (r < divisorCorr) {
                 output = i;
                 return true;
@@ -209,8 +209,8 @@ inline bool div_rounded(int64 &output, int64 a, int64 b) {
             output = (a - divisorCorr) / b;
             return true;
         } else {
-            int64 i = a / b;
-            int64 r = a - i * b;
+            const int64 i = a / b;
+            const int64 r = a - i * b;
             if (r < divisorCorr) {
                 output = i;
                 return true;


### PR DESCRIPTION
Test case (catch2 framework) that was previously failing and that passes with the fix:

```
TEST_CASE("", "[decimal]")
{
    const dec::decimal<7> n{922337203685.4};
    REQUIRE(n.getAsInteger() == 922337203685);
}
```

Previously, `getAsInteger()` would return 0 due to 922337203685.4 being too close to the maximum representable value of 922337203685.4775807.

Could use modulus operator % instead.