### PR TITLE
Correct output to stream after decimal place when a locale has been set.

### DIFF
--- a/include/decimal.h
+++ b/include/decimal.h
@@ -1705,8 +1705,8 @@ decimal<Prec, RoundPolicy> decimal_cast(const char (&arg)[N]) {
             output << "-";
         }
 
+        std::locale oldloc = output.getloc();
         if (format.thousands_grouping() && format.change_thousands_if_needed()) {
-            std::locale oldloc = output.getloc();
             output.imbue( std::locale( std::locale::classic(), new decimal_format_punct(format) ) );
             output << before;
             output.imbue(oldloc);
@@ -1715,9 +1715,11 @@ decimal<Prec, RoundPolicy> decimal_cast(const char (&arg)[N]) {
         }
 
         if (arg.getDecimalPoints() > 0) {
+            output.imbue(std::locale::classic());
             output << format.decimal_point();
             output << setw(arg.getDecimalPoints()) << setfill('0') << right
                    << after;
+            output.imbue(oldloc);
         }
     }
 


### PR DESCRIPTION
Fixes a bug where a locale set on a stream causes the numbers after the decimal point to be formatted incorrectly. This can happen if:
- A global locale is set before a stream is created, e.g. via `std::locale::global(std::locale("en_US.UTF-8"))` before `dec::toString()`
- A locale is explicitly set on the stream, e.g. via `std::cout.imbue(std::locale("en_US.UTF-8"))`

Example program:
```
using namespace dec;
using namespace std;

locale::global(locale("en_US.UTF-8"));
decimal<8> tmp(123456.7890987);
cout << toString(tmp) << endl;
```

Original output: `123,456.78,909,870`
Corrected output: `123,456.78909870`

This can get especially fun when mixing in `decimal_format`:

```
decimal_format format(',', '.');
cout << toString(tmp) << endl;
```

Original output: `123.456,78,909,870`
Corrected output: `123.456,78909870`